### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom/pom.xml
+++ b/pom/pom.xml
@@ -18,7 +18,7 @@
 		<dependency.log4j.version>1.2.14</dependency.log4j.version>
 		<dependency.commons-io.version>2.3</dependency.commons-io.version>
 		<dependency.commons-beanutils.version>1.8.3</dependency.commons-beanutils.version>
-		<dependency.commons-collections.version>3.2.1</dependency.commons-collections.version>
+		<dependency.commons-collections.version>3.2.2</dependency.commons-collections.version>
 		<dependency.cxf.version>2.6.3</dependency.cxf.version>
 		<dependecy.commons-dbcp.version>1.4</dependecy.commons-dbcp.version>
 		<dependency.openjpa.version>2.2.0</dependency.openjpa.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
